### PR TITLE
Cambio getAllProducts use pag y pase 8 registros

### DIFF
--- a/api/src/controller/getAllProducts.ts
+++ b/api/src/controller/getAllProducts.ts
@@ -4,7 +4,7 @@ import { Op } from 'sequelize';
 
 const getAllProducts = async (req: Request, res: Response) => {
   try {
-    const { type, price, IBU, ABV, qualification, order, page, name } = req.query;
+    const { type, price, IBU, ABV, qualification, order, pag, name } = req.query;
 
     // Definir las opciones de consulta
     const options: any = {};
@@ -51,10 +51,10 @@ const getAllProducts = async (req: Request, res: Response) => {
     }
 
     // Cantidad de productos a mostrar por página
-    const itemsPerPage = 15;
+    const itemsPerPage = 8;
 
     // Calcular el offset para la página actual
-    const currentPage = parseInt(page as string) || 1;
+    const currentPage = parseInt(pag as string) || 1;
     const offset = (currentPage - 1) * itemsPerPage;
 
     // Obtener productos paginados


### PR DESCRIPTION
Configuro getAllProduct para que reciba "pag" como parámetro de paginación y envíe 8 registros por solicitud.