### PR TITLE
Corrijo filtro qualification

### DIFF
--- a/api/src/controller/getAllProducts.ts
+++ b/api/src/controller/getAllProducts.ts
@@ -31,7 +31,7 @@ const getAllProducts = async (req: Request, res: Response) => {
 
     // Si se proporciona un query param 'qualification', filtrar por qualification mayor o igual
     if (qualification) {
-      options.where = { ...options.where, qualification: { [Op.gte]: qualification } };
+      options.where = { ...options.where, qualification: { [Op.lte]: qualification } };
     }
 
       // Si se proporciona un query param 'name', filtrar por nombre que contiene el valor


### PR DESCRIPTION
En getAllProducts cambio el filtro de qualification para que devuelva las cervezas que están por debajo de la calificación seleccionada.